### PR TITLE
Fix a few small typographic errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,11 +139,11 @@ Find local branches older than 10 days:
 
 Find remote branches older than 60 days:
 
-    $ git old-branches -r -d 10
+    $ git old-branches -r -d 60
 
 Find local and remote branches older than 120 days:
 
-    $ git old-branches -a -d 10
+    $ git old-branches -a -d 120
 
 Find and remove branches older than 10 days:
 

--- a/git-old-branches
+++ b/git-old-branches
@@ -25,7 +25,7 @@ import gitutils as mod_gitutils
 mod_gitutils.assert_in_git_repository()
 
 parser = mod_argparse.ArgumentParser(
-         description='Detectes (and possibly deletes) old unused branches')
+         description='Detects (and possibly deletes) old unused branches')
 
 parser.add_argument('-r', '--remote', action='store_true',
                     default=False, help='Get remote branches')
@@ -34,7 +34,7 @@ parser.add_argument('-a', '--all', action='store_true',
 parser.add_argument('-d', '--days', default=180, type=int,
                     help='How many days old must a branch be')
 parser.add_argument('--delete', action='store_true', default=False,
-                    help='Remove branches older than ... days (you\ll be asked to confirm the deletion)')
+                    help='Remove branches older than ... days (you\'ll be asked to confirm the deletion)')
 
 args = parser.parse_args()
 


### PR DESCRIPTION
- Bring the day count in the `README.md` examples into line with the
  descriptions.
- In `git-old-branches`, change 'Detectes' to 'Detects', and reinstate
  an escaped apostrophe.