### PR TITLE
add more detailed info in ahead/behind/divergence message of git-relation

### DIFF
--- a/git-relation
+++ b/git-relation
@@ -29,6 +29,8 @@ parser.add_argument('branch_1', metavar='branch_1', type=str,
                    help='the one commit/tag/branch')
 parser.add_argument('branch_2', metavar='branch_2', type=str, nargs='?', default='HEAD',
                    help='the other commit/tag/branch (default HEAD)')
+parser.add_argument('-b', '--brief', action='store_true',
+                    default=False, help='brief output')
 
 args = parser.parse_args()
 
@@ -55,6 +57,7 @@ def print_log(commit_1, commit_2):
 
     lines = result.split('\n')
 
+    print
     print '%s commits from \033[1;34m%s\033[0m to \033[1;34m%s\033[0m:' % (len(lines), commit_1, commit_2)
 
     if len(lines) < 30:
@@ -67,6 +70,15 @@ def print_log(commit_1, commit_2):
     lines = first + ['   ...%s more commits...' % (len(lines) - len(first) - len(last))] + last
 
     print '\n'.join(lines)
+
+def distance_to_commit(commit_1, commit_2):
+    success, log = mod_gitutils.execute_git(
+        'rev-list %s..%s --count' % (commit_1, commit_2),
+        output=False)
+    if not success:
+        print 'Error calculating distance between %s..%s' % (commit_1, commit_2)
+        mod_sys.exit(1)
+    return int(log)
 
 branch_1_sha1 = get_git_sha1(branch_1)
 branch_2_sha1 = get_git_sha1(branch_2)
@@ -81,16 +93,16 @@ if not success:
 elif merge_base == branch_1_sha1 and merge_base == branch_2_sha1:
     print '\033[1;34m%s\033[0m \033[1;31mEQUALS\033[0m \033[1;34m%s\033[0m' % (branch_1, branch_2)
 elif merge_base == branch_1_sha1:
-    print '\033[1;34m%s\033[0m is \033[1;31mBEHIND\033[0m \033[1;34m%s\033[0m' % (branch_1, branch_2)
-    print
-    print_log(branch_1, branch_2)
+    print '\033[1;34m%s\033[0m is \033[1;31mBEHIND\033[0m \033[1;34m%s\033[0m by %d commits' % (branch_1, branch_2, distance_to_commit(branch_1, branch_2))
+    if not args.brief:
+        print_log(branch_1, branch_2)
 elif merge_base == branch_2_sha1:
-    print '\033[1;34m%s\033[0m is \033[1;31mAHEAD\033[0m of \033[1;34m%s\033[0m' % (branch_1, branch_2)
-    print
-    print_log(branch_2, branch_1)
+    print '\033[1;34m%s\033[0m is \033[1;31mAHEAD\033[0m of \033[1;34m%s\033[0m by %d commits' % (branch_1, branch_2, distance_to_commit(branch_2, branch_1))
+    if not args.brief:
+        print_log(branch_2, branch_1)
 else:
-    print '\033[1;34m%s\033[0m and \033[1;34m%s\033[0m \033[1;31mDIVERGED\033[0m, common point is \033[1;34m%s\033[0m' % (branch_1, branch_2, merge_base)
-    print
-    print_log(merge_base, branch_1)
-    print
-    print_log(merge_base, branch_2)
+    print '\033[1;34m%s\033[0m and \033[1;34m%s\033[0m \033[1;31mDIVERGED\033[0m by respectively %d and %d commits' % (branch_1, branch_2, distance_to_commit(merge_base, branch_1), distance_to_commit(merge_base, branch_2))
+    if not args.brief:
+        print 'common point is \033[1;34m%s\033[0m'%(merge_base)
+        print_log(merge_base, branch_1)
+        print_log(merge_base, branch_2)

--- a/git-relation
+++ b/git-relation
@@ -89,7 +89,7 @@ elif merge_base == branch_2_sha1:
     print
     print_log(branch_2, branch_1)
 else:
-    print '\033[1;34m%s\033[0m and %s \033[1;31mDIVERGED\033[0m, common point is \033[1;34m%s\033[0m' % (branch_1, branch_2, merge_base)
+    print '\033[1;34m%s\033[0m and \033[1;34m%s\033[0m \033[1;31mDIVERGED\033[0m, common point is \033[1;34m%s\033[0m' % (branch_1, branch_2, merge_base)
     print
     print_log(merge_base, branch_1)
     print

--- a/git-relation
+++ b/git-relation
@@ -15,29 +15,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-Show a relation between two git commits/tags/branches.
-"""
-
 import sys as mod_sys
+import argparse as mod_argparse
 
 import gitutils as mod_gitutils
 
 mod_gitutils.assert_in_git_repository()
 
-branches = mod_sys.argv[1:]
+parser = mod_argparse.ArgumentParser(
+    description='Show a relation between two git commits/tags/branches')
 
-if not branches:
-    print 'No branches specified'
-    mod_sys.exit(1)
+parser.add_argument('branch_1', metavar='branch_1', type=str,
+                   help='the one commit/tag/branch')
+parser.add_argument('branch_2', metavar='branch_2', type=str, nargs='?', default='HEAD',
+                   help='the other commit/tag/branch (default HEAD)')
 
-if len(branches) == 1:
-    branches = ['HEAD'] + branches
+args = parser.parse_args()
 
-if len(branches) != 2:
-    print 'Two branches expected, got %s' % branches
-    mod_sys.exit(1)
-
+branch_1 = args.branch_1
+branch_2 = args.branch_2
 
 def get_git_sha1(branch_name):
     success, sha1 = mod_gitutils.execute_git('log -1 %s --format=%%H' % branch_name,
@@ -71,9 +67,6 @@ def print_log(commit_1, commit_2):
     lines = first + ['   ...%s more commits...' % (len(lines) - len(first) - len(last))] + last
 
     print '\n'.join(lines)
-
-branch_1 = branches[0]
-branch_2 = branches[1]
 
 branch_1_sha1 = get_git_sha1(branch_1)
 branch_2_sha1 = get_git_sha1(branch_2)


### PR DESCRIPTION
git-relation will now say one of the following:
HEAD EQUALS develop
HEAD is BEHIND develop by 1 commits
HEAD is AHEAD of develop by 1 commits
HEAD and develop DIVERGED by respectively 1 and 2 commits

an option '--brief' was added to hide the log of commits.

the option parsing was changed to use argparse.

a missing color was fixed in the output.