### PR TITLE
Add --depth option to git-multi 

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ With:
 
 A .tar archive named git-repositories-yyyy-mm-dd-hh-mm.tar with all repositories in this directory (i.e. their .git directories) will be created.
 
+If you have a nested structure of repositories, e.g. ~/project1/repository1, ~/project1/repository2, ~/project2/repository3, use
+    
+    git multi -d 2
+
+... or a different number to look for git repositories up to the specified depth.
+
 ### Group by output
 
 If you have many projects with same git commant output, for example:

--- a/git-multi
+++ b/git-multi
@@ -26,8 +26,6 @@ import gitutils as mod_gitutils
 PREFIX = '\t'
 
 args = mod_sys.argv[1:]
-current_path = mod_os.getcwd()
-
 # If true, projects with same git command output will be groupped together:
 group_by_output = True
 
@@ -63,11 +61,28 @@ def has_arg(args, short_name, long_name):
 
 
 def is_ignored(project):
-    return file_name in ignore_projects
+    return project in ignore_projects
+
+
+def process_dir(dirname, depth):
+    abs_dir_name = mod_os.path.abspath(dirname)
+    for file_name in mod_os.listdir(dirname):
+        if not single_project or single_project == file_name:
+            mod_os.chdir(abs_dir_name)
+
+            if mod_path.isdir(file_name):
+                if mod_path.exists('%s/.git' % file_name):
+                    process_project(abs_dir_name, file_name)
+
+                    if show_progress and group_by_output:
+                        print '*',
+                        mod_sys.stdout.flush()
+                elif depth > 1:
+                    process_dir(mod_os.path.join(abs_dir_name, file_name), depth - 1)
 
 
 def process_project(current_path, file_name):
-    if is_ignored(file_name in ignore_projects):
+    if is_ignored(file_name):
         return
 
     dir_path = '%s/%s' % (current_path, file_name)
@@ -145,6 +160,9 @@ only_if_changed = has_arg(args, 'c', 'changed')
 branch = has_arg(args, 'b', 'branch')
 branch_verbose = has_arg(args, 'bv', 'branch-verbose')
 
+# Specify depth for recursive search
+depth = int(get_arg(args, 'd', 'depth') or "1")
+
 # Compute projects to be executed:
 ignore_projects = []
 if mod_path.exists('.multigit_ignore'):
@@ -202,17 +220,8 @@ if show_progress and group_by_output:
     mod_sys.stdout.flush()
 
 # Execute command on all subdirectories:
-for file_name in mod_os.listdir('.'):
-    if not single_project or single_project == file_name:
-        mod_os.chdir(current_path)
+process_dir(mod_os.getcwd(), depth)
 
-        if mod_path.isdir(file_name):
-            if mod_path.exists('%s/.git' % file_name):
-                process_project(current_path, file_name)
-
-                if show_progress and group_by_output:
-                    print '*',
-                    mod_sys.stdout.flush()
 if show_progress and group_by_output:
     print
     print '--------------------------------------------------------------------------------'


### PR DESCRIPTION
In some projects, I like to have my repositories structured into subfolders. 

This PR adds the `-d`/`--depth` parameter to `git-multi` to be able to run operations on all repositories in nested folders. 