### PR TITLE
add nixos compatible shebangs

### DIFF
--- a/git-multi
+++ b/git-multi
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # Copyright 2013 Tomo Krajina

--- a/git-old-branches
+++ b/git-old-branches
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # Copyright 2013 Tomo Krajina

--- a/git-recent
+++ b/git-recent
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # Copyright 2013 Tomo Krajina

--- a/git-relation
+++ b/git-relation
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # Copyright 2013 Tomo Krajina

--- a/gitutils/__init__.py
+++ b/gitutils/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 import os.path as mod_path

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # Copyright 2013 Tomo Krajina
 #


### PR DESCRIPTION
Those are not only NixOS compatible but allow to use PATH variable to select a version of python that should be executed to interpret the scripts. https://stackoverflow.com/questions/21612980/why-is-usr-bin-env-bash-superior-to-bin-bash